### PR TITLE
new: break: feat: add support of encoder based on interrupts. 

### DIFF
--- a/Evol/Evol.ino
+++ b/Evol/Evol.ino
@@ -23,13 +23,14 @@ Adafruit_PCD8544 display = Adafruit_PCD8544(15, 16, 18, 19, 21);
 #define ENCODER_CLK_PIN 2  //Nano has interrupt on pin 2
 #define ENCODER_DT_PIN 7   // Can be any other digital pin
 #define ENCODER_RANGE 36
+#define ENCODER_OFF_STATE 2
 
 //encoder section
 
 //encoder state vars
 volatile int encoderValue = 0;
-volatile int aPrevious;
-volatile int bPrevious;
+volatile int aPrevious = ENCODER_OFF_STATE;
+volatile int bPrevious = ENCODER_OFF_STATE;
 
 
 /* Encoder interrupt routine
@@ -42,9 +43,16 @@ void readEncoder() {
   int b = digitalRead(ENCODER_DT_PIN);
   if (a != aPrevious) {                  
     aPrevious = a;
+
+    if (bPrevious == ENCODER_OFF_STATE) {
+      bPrevious = b;
+      return;
+    }
+
     if (b != bPrevious) {
       bPrevious = b;
       processEncoderRotation(a == b);
+      bPrevious = ENCODER_OFF_STATE;
     }
   }
 }

--- a/Evol/Evol.ino
+++ b/Evol/Evol.ino
@@ -22,7 +22,7 @@ Adafruit_PCD8544 display = Adafruit_PCD8544(15, 16, 18, 19, 21);
 
 #define ENCODER_CLK_PIN 2  //Nano has interrupt on pin 2
 #define ENCODER_DT_PIN 7   // Can be any other digital pin
-#define ENCODER_CLICKS_PER_ROTATION 36
+#define ENCODER_RANGE 36
 
 //encoder section
 
@@ -51,7 +51,8 @@ void readEncoder() {
 
 // Encoder rotation process routine
 void processEncoderRotation (bool direction) {
-  encoderValue = max(min((encoderValue + (direction ? 1 : -1)), ENCODER_CLICKS_PER_ROTATION), 0);
+  encoderValue = max(min((encoderValue + (direction ? 1 : -1)), ENCODER_RANGE), 
+0);
   Serial.println(encoderValue);
   if (direction == true) {
     Serial.println ("CW");


### PR DESCRIPTION
Old code must be adopted to a new encoder state variable.
New version of encoder supports state value variable encoderValue (absolute value from 0 to ENCODER_CLICKS_PER_ROTATION).

readEncoder() int routine calls encoder state processing func with bool argument indicating rotation direction.

interrupt currently in DP 2 CHANGING. 